### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A local agent that monitors the system clipboard, uploads any copied image to Supabase Storage, then writes the public (or signed) URL back to the clipboard.
 
+<a href="https://glama.ai/mcp/servers/@martinbowling/clipboard-to-supabase-mcp-helper">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@martinbowling/clipboard-to-supabase-mcp-helper/badge" alt="Clipboard to Supabase Helper MCP server" />
+</a>
+
 ## Features
 
 - Zero-click image hosting: Copy an image, get a URL instantly


### PR DESCRIPTION
This PR adds a badge for the [Clipboard to Supabase MCP Helper](https://glama.ai/mcp/servers/@martinbowling/clipboard-to-supabase-mcp-helper) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@martinbowling/clipboard-to-supabase-mcp-helper">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@martinbowling/clipboard-to-supabase-mcp-helper/badge" alt="Clipboard to Supabase Helper MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.